### PR TITLE
Update 'rpi-gateway' link text to 'm17-gateway'

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Other Pi models or OS versions may work but are **not officially supported**.
 
 This script builds an M17 hotspot which consists of two software components:
 
-- [rpi-gateway](https://github.com/jancona/m17)
+- [m17-gateway](https://github.com/jancona/m17)
 - [rpi-dashboard](https://github.com/M17-Project/rpi-dashboard)
 
 Please read the manual of both software packages.


### PR DESCRIPTION
This PR changes the hyperlink link text for 'https://github.com/jancona/m17' from 'rpi-gateway' to 'm17-gateway' to reflect the proper name used in the jancona/m17 repository. 